### PR TITLE
Add DevL.Extensions library and CI/CD workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,65 @@
+name: release
+
+on:
+  push:
+    tags:
+      - 'v*.*.*'   # e.g., v1.0.0
+
+jobs:
+  build-pack-publish:
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: write    # needed for creating a GitHub Release
+
+    env:
+      VERSION: ${{ startsWith(github.ref, 'refs/tags/') && replace(github.ref_name, 'v', '') || '0.0.0-local' }}
+
+    steps:
+      - name: Check out
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Set up .NET
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: '10.x'
+
+      - name: Restore
+        run: dotnet restore
+
+      - name: Build
+        run: dotnet build src/DevL.Extensions/DevL.Extensions.csproj -c Release --no-restore
+
+      - name: Test (skip if none)
+        run: echo "No tests yet"
+
+      - name: Pack
+        run: dotnet pack src/DevL.Extensions/DevL.Extensions.csproj -c Release -o artifacts -p:PackageVersion=${{ env.VERSION }}
+
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: nupkgs
+          path: artifacts/*.*
+
+      - name: Publish to NuGet.org
+        if: startsWith(github.ref, 'refs/tags/')
+        run: |
+          dotnet nuget push artifacts/*.nupkg \
+            --source https://api.nuget.org/v3/index.json \
+            --api-key ${{ secrets.NUGET_API_KEY }} \
+            --skip-duplicate
+
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v2
+        if: startsWith(github.ref, 'refs/tags/')
+        with:
+          name: v${{ env.VERSION }}
+          draft: false
+          prerelease: false
+          generate_release_notes: true
+          files: |
+            artifacts/*.nupkg
+            artifacts/*.snupkg

--- a/DevL.Utilities.slnx
+++ b/DevL.Utilities.slnx
@@ -1,0 +1,3 @@
+<Solution>
+  <Project Path="src/DevL.Extensions/DevL.Extensions.csproj" Id="24ec9b37-5c23-4728-a2da-fe1d76bcceae" />
+</Solution>

--- a/src/DevL.Extensions/DevL.Extensions.csproj
+++ b/src/DevL.Extensions/DevL.Extensions.csproj
@@ -1,0 +1,33 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <PackageTags>extensions;utilities;devl</PackageTags>
+    <RepositoryType>git</RepositoryType>
+    <RepositoryUrl>https://github.com/devl-things/utils</RepositoryUrl>
+    <Description>Common .NET extensions</Description>
+    <PackageReadmeFile>README.md</PackageReadmeFile>
+    <PackageLicenseFile>LICENSE</PackageLicenseFile>
+    <IncludeSymbols>True</IncludeSymbols>
+    <SymbolPackageFormat>snupkg</SymbolPackageFormat>
+    <PackageProjectUrl>https://github.com/devl-things/utils</PackageProjectUrl>
+	<PublishRepositoryUrl>true</PublishRepositoryUrl>
+	<EmbedUntrackedSources>true</EmbedUntrackedSources>
+	<ContinuousIntegrationBuild>true</ContinuousIntegrationBuild>
+	<Deterministic>true</Deterministic>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <None Include="..\..\LICENSE">
+      <Pack>True</Pack>
+      <PackagePath>\</PackagePath>
+    </None>
+    <None Include="..\..\README.md">
+      <Pack>True</Pack>
+      <PackagePath>\</PackagePath>
+    </None>
+  </ItemGroup>
+
+</Project>

--- a/src/DevL.Extensions/DictionaryExtensions.cs
+++ b/src/DevL.Extensions/DictionaryExtensions.cs
@@ -1,0 +1,18 @@
+﻿using System.Runtime.InteropServices;
+
+namespace DevL.Extensions
+{
+    public static class DictionaryExtensions
+    {
+        public static TValue GetOrAdd<TKey, TValue>(this Dictionary<TKey, TValue> dictionary, TKey key, TValue value) where TKey : notnull
+        {
+            ref TValue? val = ref CollectionsMarshal.GetValueRefOrAddDefault<TKey, TValue>(dictionary, key, out bool exists);
+            if (exists)
+            {
+                return val!;
+            }
+            val = value!;
+            return value;
+        }
+    }
+}

--- a/src/DevL.Extensions/IAsyncEnumerableExtensions.cs
+++ b/src/DevL.Extensions/IAsyncEnumerableExtensions.cs
@@ -1,0 +1,34 @@
+﻿using System.Runtime.CompilerServices;
+
+namespace DevL.Extensions
+{
+    public static class IAsyncEnumerableExtensions
+    {
+        public static readonly IAsyncEnumerable<object> Empty = EmptyAsync();
+
+        private static async IAsyncEnumerable<object> EmptyAsync()
+        {
+            yield break;
+        }
+
+        /// <summary>
+        /// Creates an async enumerable that returns a single value.
+        /// </summary>
+        public static async IAsyncEnumerable<T> ToAsyncEnumerable<T>(this T value)
+        {
+            yield return value;
+        }
+
+        /// <summary>
+        /// Creates an async enumerable from a regular enumerable.
+        /// </summary>
+        public static async IAsyncEnumerable<T> ToAsyncEnumerable<T>(this IEnumerable<T> source, [EnumeratorCancellation] CancellationToken cancellationToken = default)
+        {
+            foreach (var item in source)
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+                yield return item;
+            }
+        }
+    }
+}


### PR DESCRIPTION
Introduced a new `DevL.Extensions` library with utility extensions for `Dictionary` and `IAsyncEnumerable`. Added a GitHub Actions workflow to automate build, test, packaging, and publishing processes, including NuGet.org publishing and GitHub Releases.

Key changes:
- Added `release.yml` for CI/CD automation.
- Created `DevL.Extensions.csproj` targeting .NET 10.0 with modern build configurations.
- Added `DictionaryExtensions` with a `GetOrAdd` method.
- Added `IAsyncEnumerableExtensions` with `Empty` and `ToAsyncEnumerable` methods.
- Updated solution file to include the new project.